### PR TITLE
fix: search input no focus when it displayed

### DIFF
--- a/src/components/BaseTable.vue
+++ b/src/components/BaseTable.vue
@@ -150,7 +150,8 @@ defineRender(
                               clearable
                               modelValue={searchKey}
                               onUpdate:modelValue={debounce(e => searchKey = e)}
-                              class="flex-1">
+                              class="flex-1"
+                              autofocus>
                             {{
                               subfix: () => <IconFluentSearch24Regular
                                   class="text-lg text-gray"


### PR DESCRIPTION
修复：单词列表点击搜索，输入框默认没有焦点
<img width="884" height="304" alt="image" src="https://github.com/user-attachments/assets/9ec95698-106a-460c-8cec-21566c0f4fab" />
↓
<img width="662" height="229" alt="image" src="https://github.com/user-attachments/assets/66bcd5e3-b2ba-4bb0-bbe9-3b5bb518dde8" />

修复后：
<img width="667" height="282" alt="image" src="https://github.com/user-attachments/assets/33fa305d-1ac4-43c9-beac-31d5d3d819f5" />
