### PR TITLE
fix: two clicks are needed to chenge the theme for the first time

### DIFF
--- a/src/hooks/theme.ts
+++ b/src/hooks/theme.ts
@@ -1,33 +1,71 @@
 import {useSettingStore} from "@/stores/setting.ts";
 
+type Theme = "light" | "dark";
+// 获取系统主题
+function getSystemTheme(): Theme {
+  if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+     return 'dark';
+  } else if (window.matchMedia('(prefers-color-scheme: light)').matches) {
+      return 'light';
+  }
+  return 'light'; // 默认浅色模式
+}
+
+// 交换主题名称
+function swapTheme(theme: Theme): Theme {
+  return theme === 'light' ? 'dark' : 'light'
+}
+
+// 监听系统主题变化
+function listenToSystemThemeChange(call: (theme: Theme) => void) {
+    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', e => {
+        if (e.matches) {
+            // console.log('系统已切换到深色模式');
+            call('dark');
+        }
+    });
+    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', e => {
+        if (e.matches) {
+            // console.log('系统已切换到浅色模式');
+            call('light');
+        }
+    });
+}
+
 export default function useTheme() {
   const settingStore = useSettingStore()
 
-// // 查询当前系统主题颜色
-//   const match: MediaQueryList = window.matchMedia("(prefers-color-scheme: dark)")
-// // 监听系统主题变化
-//   match.addEventListener('change', followSystem)
-//
-//   function followSystem() {
-//     document.documentElement.className = match.matches ? 'dark' : 'light'
-//   }
-
+  // 开启监听系统主题变更,后期可以通过用户配置来决定是否开启
+  listenToSystemThemeChange((theme: Theme) => {
+    // 如果系统主题变更后和当前的主题一致，则不需要再重新切换
+    if(settingStore.theme === theme){
+        return;
+    }
+    
+    settingStore.theme = theme;
+    setTheme(theme);
+  })
 
   function toggleTheme() {
-    if (settingStore.theme === 'auto') {
-      settingStore.theme = 'light'
-    } else {
-      settingStore.theme = settingStore.theme === 'light' ? 'dark' : 'light'
-    }
-    setTheme(settingStore.theme)
+    // auto模式下，默认是使用系统主题，切换时应该使用当前系统主题为基础进行切换
+    settingStore.theme = swapTheme(settingStore.theme === 'auto' ? getSystemTheme() : settingStore.theme as Theme);
+    setTheme(settingStore.theme);
   }
 
-  function setTheme(val) {
-    document.documentElement.className = val
+  function setTheme(val:string) {
+    // auto模式下，则通过查询系统主题来设置主题名称
+    document.documentElement.className = val === 'auto' ? getSystemTheme() : val;
+  }
+
+  // 获取当前具体的主题名称
+  function getTheme():Theme{
+    // auto模式下，则通过查询系统主题来获取当前具体的主题名称
+    return settingStore.theme === 'auto' ? getSystemTheme() : settingStore.theme as Theme;
   }
 
   return {
     toggleTheme,
-    setTheme
+    setTheme,
+    getTheme
   }
 }

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -12,7 +12,7 @@ import {useRuntimeStore} from "@/stores/runtime.ts";
 const settingStore = useSettingStore()
 const runtimeStore = useRuntimeStore()
 const router = useRouter()
-const {toggleTheme} = useTheme()
+const {toggleTheme,getTheme} = useTheme()
 
 
 </script>
@@ -58,7 +58,7 @@ const {toggleTheme} = useTheme()
             :title="`切换主题(${settingStore.shortcutKeyMap[ShortcutKey.ToggleTheme]})`"
             @click="toggleTheme"
         >
-          <IconFluentWeatherMoon16Regular v-if="settingStore.theme === 'light'"/>
+          <IconFluentWeatherMoon16Regular v-if="getTheme() === 'light'"/>
           <IconFluentWeatherSunny16Regular v-else/>
         </BaseIcon>
       </div>


### PR DESCRIPTION
修复：首次加载界面后，切换主题按钮图标错误 且 点击切换主题需要点击两次
<img width="1031" height="714" alt="image" src="https://github.com/user-attachments/assets/d0792202-1c5d-47fd-bce4-7a13725112fd" />

<img width="1044" height="740" alt="image" src="https://github.com/user-attachments/assets/ef62c001-e17b-4645-9fcb-d8146a1610ed" />

<img width="864" height="717" alt="image" src="https://github.com/user-attachments/assets/9f5b2eaf-da42-4443-a84e-d59373bffd1f" />

修改后：

首次加载，图标和主题跟随系统主题

<img width="1061" height="789" alt="image" src="https://github.com/user-attachments/assets/443a372f-f63e-47e1-81f5-88251d9f6c3c" />

<img width="957" height="790" alt="image" src="https://github.com/user-attachments/assets/6defbc62-9eec-45fb-8d5d-895bbadc44a0" />

点击一次

<img width="967" height="718" alt="image" src="https://github.com/user-attachments/assets/34ae3f10-72ad-4054-9e39-34132889bf2a" />

<img width="980" height="788" alt="image" src="https://github.com/user-attachments/assets/47827eee-cb78-43e4-abb1-16c3af5392c8" />

跟随系统主题切换而改变

<img width="3431" height="860" alt="image" src="https://github.com/user-attachments/assets/7e26c0d3-9bfc-416d-ad74-f68bfa111cfd" />

<img width="3418" height="874" alt="image" src="https://github.com/user-attachments/assets/89cac19f-0402-4146-b6be-b0509c2bf6bf" />

