### PR TITLE
fix: 调整Next按钮的位置，避免和滚动条重叠

### DIFF
--- a/src/pages/word/PracticeWords.vue
+++ b/src/pages/word/PracticeWords.vue
@@ -548,7 +548,7 @@ useEvents([
               <div class="word">{{ prevWord.word }}</div>
             </Tooltip>
           </div>
-          <div class="center gap-2 cursor-pointer float-right "
+          <div class="center gap-2 cursor-pointer float-right mr-3"
                @click="next(false)"
                v-if="nextWord">
             <Tooltip


### PR DESCRIPTION
改动前：
<img width="716" height="883" alt="图片" src="https://github.com/user-attachments/assets/af21b996-e0fc-460a-8795-4bcdfbefc1d2" />

改动后：
<img width="708" height="884" alt="图片" src="https://github.com/user-attachments/assets/cd8f1596-34fe-49fd-b3b2-0b78871652d0" />
