### PR TITLE
修复在开启"自动切换下一个单词"的情况下,循环逻辑不一致

### DIFF
--- a/app/components/word/TypeWord.vue
+++ b/app/components/word/TypeWord.vue
@@ -174,13 +174,9 @@ async function onTyping(e: KeyboardEvent) {
           return
         }
         showWordResult = inputLock = false
-        if (settingStore.wordPracticeType === WordPracticeType.FollowWrite) {
-          if (shouldRepeat()) {
-            repeat()
-          } else {
-            emit('complete')
-          }
-        }else {
+        if (shouldRepeat()) {
+          repeat()
+        } else {
           emit('complete')
         }
       } else {
@@ -335,10 +331,14 @@ async function onTyping(e: KeyboardEvent) {
 }
 
 function shouldRepeat() {
-  if (settingStore.repeatCount == 100) {
-    return settingStore.repeatCustomCount > wordRepeatCount + 1;
+  if (settingStore.wordPracticeType === WordPracticeType.FollowWrite) {
+    if (settingStore.repeatCount == 100) {
+      return settingStore.repeatCustomCount > wordRepeatCount + 1;
+    } else {
+      return settingStore.repeatCount > wordRepeatCount + 1;
+    }
   } else {
-    return settingStore.repeatCount > wordRepeatCount + 1;
+    return false;
   }
 }
 


### PR DESCRIPTION
在开启"自动切换下一个单词"的情况下,循环逻辑与关闭的情况不一致
将开启情况下的逻辑修复为关闭情况下的逻辑