### PR TITLE
feat: 优化同步数据结构 — 来源追溯 + 动态回填，减少 Supabase 存储 80%

### DIFF
--- a/apps/nuxt/app/pages/(words)/practice-words/[id].vue
+++ b/apps/nuxt/app/pages/(words)/practice-words/[id].vue
@@ -11,7 +11,7 @@ import {
   useStartKeyboardEventListener,
 } from '@typewords/core/hooks/event.ts'
 import useTheme from '@typewords/core/hooks/theme.ts'
-import { getCurrentStudyWord, useWordOptions } from '@typewords/core/hooks/dict.ts'
+import { ensureWordSourceDictId, getCurrentStudyWord, useWordOptions } from '@typewords/core/hooks/dict.ts'
 import {
   _getDictDataByUrl,
   _nextTick,
@@ -719,9 +719,7 @@ function onTypeWrong() {
     statStore.wrong++
   }
   if (!store.wrong.words.find((v: Word) => v.word.toLowerCase() === temp)) {
-    if (!word.sourceDictId && store.sdict.id) {
-      word.sourceDictId = store.sdict.id
-    }
+    ensureWordSourceDictId(word, store.sdict.id)
     store.wrong.words.push(word)
     store.wrong.length = store.wrong.words.length
   }

--- a/apps/nuxt/app/pages/(words)/practice-words/[id].vue
+++ b/apps/nuxt/app/pages/(words)/practice-words/[id].vue
@@ -719,6 +719,9 @@ function onTypeWrong() {
     statStore.wrong++
   }
   if (!store.wrong.words.find((v: Word) => v.word.toLowerCase() === temp)) {
+    if (!word.sourceDictId && store.sdict.id) {
+      word.sourceDictId = store.sdict.id
+    }
     store.wrong.words.push(word)
     store.wrong.length = store.wrong.words.length
   }

--- a/apps/nuxt/i18n/locales/de.json
+++ b/apps/nuxt/i18n/locales/de.json
@@ -195,6 +195,7 @@
 	"uncollect": "Favorit entfernen",
 	"mark_mastered": "Als gemeistert markieren",
 	"unmark_mastered": "Gemeistert-Markierung entfernen",
+	"missing_dict_hint": "Download {dictName} to view full definitions",
 	"about_thanks": "Danke für die Nutzung dieses Projekts! Es ist ein Open-Source-Projekt, kostenlos nutzbar. Wenn es hilfreich war, geben Sie uns einen Stern auf GitHub!",
 	"github_address": "GitHub:",
 	"about_wechat_feedback": "WeChat-Feedback:",

--- a/apps/nuxt/i18n/locales/en.json
+++ b/apps/nuxt/i18n/locales/en.json
@@ -195,6 +195,7 @@
 	"uncollect": "Unfavorite",
 	"mark_mastered": "Mark as Mastered",
 	"unmark_mastered": "Unmark Mastered",
+	"missing_dict_hint": "Download {dictName} to view full definitions",
 	"about_thanks": "Thank you for using this project! It is open source and free. If helpful, please star us on GitHub. Your support motivates our improvement!",
 	"github_address": "GitHub: ",
 	"about_wechat_feedback": "WeChat Feedback: ",

--- a/apps/nuxt/i18n/locales/es.json
+++ b/apps/nuxt/i18n/locales/es.json
@@ -195,6 +195,7 @@
 	"uncollect": "Quitar favorito",
 	"mark_mastered": "Marcar como dominado",
 	"unmark_mastered": "Desmarcar dominado",
+	"missing_dict_hint": "Download {dictName} to view full definitions",
 	"about_thanks": "¡Gracias por usar este proyecto! Es un proyecto de código abierto, de uso gratuito. Si le resulta útil, ¡déjenos una estrella en GitHub!",
 	"github_address": "GitHub:",
 	"about_wechat_feedback": "Comentarios de WeChat:",

--- a/apps/nuxt/i18n/locales/fr.json
+++ b/apps/nuxt/i18n/locales/fr.json
@@ -195,6 +195,7 @@
 	"uncollect": "Retirer des favoris",
 	"mark_mastered": "Marquer comme maîtrisé",
 	"unmark_mastered": "Démarquer comme maîtrisé",
+	"missing_dict_hint": "Download {dictName} to view full definitions",
 	"about_thanks": "Merci d'utiliser ce projet ! C'est un projet open source, gratuit. Si vous le trouvez utile, mettez-nous une étoile sur GitHub !",
 	"github_address": "GitHub:",
 	"about_wechat_feedback": "Retour WeChat:",

--- a/apps/nuxt/i18n/locales/id.json
+++ b/apps/nuxt/i18n/locales/id.json
@@ -195,6 +195,7 @@
 	"uncollect": "Batal favorit",
 	"mark_mastered": "Tandai sebagai dikuasai",
 	"unmark_mastered": "Hapus tanda dikuasai",
+	"missing_dict_hint": "Download {dictName} to view full definitions",
 	"about_thanks": "Terima kasih telah menggunakan proyek ini! Ini adalah proyek open source, gratis digunakan. Jika bermanfaat, beri kami bintang di GitHub!",
 	"github_address": "GitHub:",
 	"about_wechat_feedback": "Umpan Balik WeChat:",

--- a/apps/nuxt/i18n/locales/ja.json
+++ b/apps/nuxt/i18n/locales/ja.json
@@ -195,6 +195,7 @@
 	"uncollect": "お気に入り解除",
 	"mark_mastered": "習得済みとしてマーク",
 	"unmark_mastered": "習得済みマーク解除",
+	"missing_dict_hint": "Download {dictName} to view full definitions",
 	"about_thanks": "ご利用ありがとうございます！これはオープンソースプロジェクトで、無料でご利用いただけます。役に立った場合は、GitHubでスターをお願いします！",
 	"github_address": "GitHub:",
 	"about_wechat_feedback": "WeChatフィードバック:",

--- a/apps/nuxt/i18n/locales/ko.json
+++ b/apps/nuxt/i18n/locales/ko.json
@@ -195,6 +195,7 @@
 	"uncollect": "즐겨찾기 해제",
 	"mark_mastered": "마스터로 표시",
 	"unmark_mastered": "마스터 표시 해제",
+	"missing_dict_hint": "Download {dictName} to view full definitions",
 	"about_thanks": "이 프로젝트를 사용해 주셔서 감사합니다! 이것은 무료로 사용할 수 있는 오픈소스 프로젝트입니다. 도움이 되셨다면 GitHub에서 스타를 눌러주세요!",
 	"github_address": "GitHub:",
 	"about_wechat_feedback": "WeChat 피드백:",

--- a/apps/nuxt/i18n/locales/pt.json
+++ b/apps/nuxt/i18n/locales/pt.json
@@ -195,6 +195,7 @@
 	"uncollect": "Desfavoritar",
 	"mark_mastered": "Marcar como dominado",
 	"unmark_mastered": "Desmarcar dominado",
+	"missing_dict_hint": "Download {dictName} to view full definitions",
 	"about_thanks": "Obrigado por usar este projeto! É um projeto de código aberto, gratuito. Se achar útil, deixe uma estrela no GitHub!",
 	"github_address": "GitHub:",
 	"about_wechat_feedback": "Feedback do WeChat:",

--- a/apps/nuxt/i18n/locales/ru.json
+++ b/apps/nuxt/i18n/locales/ru.json
@@ -195,6 +195,7 @@
 	"uncollect": "Убрать из избранного",
 	"mark_mastered": "Отметить как освоенное",
 	"unmark_mastered": "Снять отметку освоенного",
+	"missing_dict_hint": "Download {dictName} to view full definitions",
 	"about_thanks": "Спасибо за использование проекта! Это проект с открытым кодом, бесплатный. Если нашли полезным, поставьте звезду на GitHub!",
 	"github_address": "GitHub:",
 	"about_wechat_feedback": "Отзыв в WeChat:",

--- a/apps/nuxt/i18n/locales/th.json
+++ b/apps/nuxt/i18n/locales/th.json
@@ -195,6 +195,7 @@
 	"uncollect": "ยกเลิกรายการโปรด",
 	"mark_mastered": "ทำเครื่องหมายว่าเชี่ยวชาญ",
 	"unmark_mastered": "ยกเลิกเครื่องหมายเชี่ยวชาญ",
+	"missing_dict_hint": "Download {dictName} to view full definitions",
 	"about_thanks": "ขอบคุณที่ใช้โปรเจกต์นี้! นี่คือโปรเจกต์โอเพนซอร์ส ใช้งานฟรี หากเป็นประโยชน์ กรุณาให้ดาวบน GitHub!",
 	"github_address": "GitHub:",
 	"about_wechat_feedback": "ติดต่อ WeChat:",

--- a/apps/nuxt/i18n/locales/tw.json
+++ b/apps/nuxt/i18n/locales/tw.json
@@ -195,6 +195,7 @@
 	"uncollect": "取消收藏",
 	"mark_mastered": "標記為已掌握",
 	"unmark_mastered": "取消標記已掌握",
+	"missing_dict_hint": "需要下載 {dictName} 以顯示完整內容",
 	"about_thanks": "感謝使用本项目！本项目是開源项目，免費使用，如果觉得有帮助，請在 GitHub 点個 Star，您的支持是我持續改進的動力！",
 	"github_address": "GitHub地址：",
 	"about_wechat_feedback": "微信反馈：",

--- a/apps/nuxt/i18n/locales/uk.json
+++ b/apps/nuxt/i18n/locales/uk.json
@@ -195,6 +195,7 @@
 	"uncollect": "Видалити з обраного",
 	"mark_mastered": "Позначити як освоєне",
 	"unmark_mastered": "Зняти позначку освоєного",
+	"missing_dict_hint": "Download {dictName} to view full definitions",
 	"about_thanks": "Дякуємо за використання проекту! Це проект з відкритим кодом, безкоштовний. Якщо знайшли корисним, поставте зірку на GitHub!",
 	"github_address": "GitHub:",
 	"about_wechat_feedback": "Відгук у WeChat:",

--- a/apps/nuxt/i18n/locales/vi.json
+++ b/apps/nuxt/i18n/locales/vi.json
@@ -195,6 +195,7 @@
 	"uncollect": "Bỏ yêu thích",
 	"mark_mastered": "Đánh dấu đã thành thạo",
 	"unmark_mastered": "Bỏ đánh dấu thành thạo",
+	"missing_dict_hint": "Download {dictName} to view full definitions",
 	"about_thanks": "Cảm ơn bạn đã sử dụng dự án này! Đây là dự án mã nguồn mở, miễn phí. Nếu thấy hữu ích, hãy cho chúng tôi một sao trên GitHub!",
 	"github_address": "GitHub:",
 	"about_wechat_feedback": "Phản hồi WeChat:",

--- a/apps/nuxt/i18n/locales/zh.json
+++ b/apps/nuxt/i18n/locales/zh.json
@@ -195,6 +195,7 @@
 	"uncollect": "取消收藏",
 	"mark_mastered": "标记为已掌握",
 	"unmark_mastered": "取消标记已掌握",
+	"missing_dict_hint": "需要下载 {dictName} 以显示完整内容",
 	"about_thanks": "感谢使用本项目！本项目是开源项目，免费使用，如果觉得有帮助，请在 GitHub 点个 Star，您的支持是我持续改进的动力！",
 	"github_address": "GitHub地址：",
 	"about_wechat_feedback": "微信反馈：",

--- a/apps/vscode-web/src/pages/(words)/practice-words/[id].vue
+++ b/apps/vscode-web/src/pages/(words)/practice-words/[id].vue
@@ -11,7 +11,7 @@ import {
   useStartKeyboardEventListener,
 } from '@typewords/core/hooks/event.ts'
 import useTheme from '@typewords/core/hooks/theme.ts'
-import { getCurrentStudyWord, useWordOptions } from '@typewords/core/hooks/dict.ts'
+import { ensureWordSourceDictId, getCurrentStudyWord, useWordOptions } from '@typewords/core/hooks/dict.ts'
 import {
   _getDictDataByUrl,
   _nextTick,
@@ -760,6 +760,7 @@ function onTypeWrong() {
     statStore.wrong++
   }
   if (!store.wrong.words.find((v: Word) => v.word.toLowerCase() === temp)) {
+    ensureWordSourceDictId(word, store.sdict.id)
     store.wrong.words.push(word)
     store.wrong.length = store.wrong.words.length
   }

--- a/packages/core/src/components/word/WordItem.vue
+++ b/packages/core/src/components/word/WordItem.vue
@@ -3,9 +3,12 @@ import type { Word } from '../../types'
 import { usePlayWordAudio } from '../../hooks/sound.ts'
 import { BaseIcon, Tooltip, VolumeIcon } from '@typewords/base'
 import { useWordOptions } from '../../hooks/dict.ts'
+import { useWordHydrator } from '../../hooks/useWordHydrator'
 import TranslationList from './TranslationList.vue'
+import { onMounted, watch } from 'vue'
+import { useRouter } from 'vue-router'
 
-withDefaults(
+const props = withDefaults(
   defineProps<{
     item: Word
     showTranslate?: boolean
@@ -33,6 +36,37 @@ withDefaults(
 const playWordAudio = usePlayWordAudio()
 
 const { isWordCollect, toggleWordCollect, isWordSimple, toggleWordSimple } = useWordOptions()
+
+const { hydrate } = useWordHydrator()
+const router = useRouter()
+
+let hydrateFailed = $ref(false)
+let missingDictName = $ref('')
+
+async function doHydrate(item: Word) {
+  const result = await hydrate(item)
+  if (!result.hydrated && result.dictName) {
+    hydrateFailed = true
+    missingDictName = result.dictName
+  } else if (result.hydrated) {
+    hydrateFailed = false
+  }
+}
+
+function goDictList() {
+  router.push('/dict-list')
+}
+
+onMounted(() => {
+  doHydrate(props.item)
+})
+
+watch(
+  () => props.item,
+  val => {
+    doHydrate(val)
+  }
+)
 </script>
 
 <template>
@@ -46,7 +80,10 @@ const { isWordCollect, toggleWordCollect, isWordSimple, toggleWordSimple } = use
           <span class="phonetic text-gray" :class="!showWord && 'word-shadow'">{{ item.phonetic0 }}</span>
           <VolumeIcon class="volume" @click="playWordAudio(item.word)"></VolumeIcon>
         </div>
-        <TranslationList :pos-space="false" :word="item" :showFull="showWord" v-if="showTranslate" />
+        <TranslationList :pos-space="false" :word="item" :showFull="showWord" v-if="showTranslate && !hydrateFailed" />
+        <div v-else-if="showTranslate && hydrateFailed" class="missing-dict-hint" @click="goDictList">
+          下载 {{ missingDictName }} 查看释义
+        </div>
       </div>
     </div>
     <div class="right" v-if="showOption">
@@ -74,4 +111,16 @@ const { isWordCollect, toggleWordCollect, isWordSimple, toggleWordSimple } = use
   </div>
 </template>
 
-<style scoped lang="scss"></style>
+<style scoped lang="scss">
+.missing-dict-hint {
+  color: var(--color-sub-text);
+  font-size: 0.82rem;
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  transition: color 0.15s;
+}
+.missing-dict-hint:hover {
+  color: var(--color-icon-hightlight);
+}
+</style>

--- a/packages/core/src/components/word/WordItem.vue
+++ b/packages/core/src/components/word/WordItem.vue
@@ -42,9 +42,14 @@ const router = useRouter()
 
 let hydrateFailed = $ref(false)
 let missingDictName = $ref('')
+let hydrateToken = 0
 
 async function doHydrate(item: Word) {
+  if (!props.showTranslate) return
+  const token = ++hydrateToken
   const result = await hydrate(item)
+  // 仅当 token 未过期时更新状态，避免竞态导致旧结果覆盖当前单词
+  if (token !== hydrateToken) return
   if (!result.hydrated && result.dictName) {
     hydrateFailed = true
     missingDictName = result.dictName
@@ -81,9 +86,9 @@ watch(
           <VolumeIcon class="volume" @click="playWordAudio(item.word)"></VolumeIcon>
         </div>
         <TranslationList :pos-space="false" :word="item" :showFull="showWord" v-if="showTranslate && !hydrateFailed" />
-        <div v-else-if="showTranslate && hydrateFailed" class="missing-dict-hint" @click="goDictList">
+        <button v-else-if="showTranslate && hydrateFailed" class="missing-dict-hint" @click="goDictList">
           下载 {{ missingDictName }} 查看释义
-        </div>
+        </button>
       </div>
     </div>
     <div class="right" v-if="showOption">
@@ -119,6 +124,10 @@ watch(
   text-decoration: underline;
   text-underline-offset: 2px;
   transition: color 0.15s;
+  background: none;
+  border: none;
+  padding: 0;
+  font-family: inherit;
 }
 .missing-dict-hint:hover {
   color: var(--color-icon-hightlight);

--- a/packages/core/src/components/word/WordItem.vue
+++ b/packages/core/src/components/word/WordItem.vue
@@ -55,6 +55,7 @@ async function doHydrate(item: Word) {
     missingDictName = result.dictName
   } else if (result.hydrated) {
     hydrateFailed = false
+    missingDictName = ''
   }
 }
 
@@ -72,6 +73,19 @@ watch(
     doHydrate(val)
   }
 )
+
+watch(
+  () => props.showTranslate,
+  val => {
+    if (val) {
+      doHydrate(props.item)
+      return
+    }
+    hydrateToken++
+    hydrateFailed = false
+    missingDictName = ''
+  }
+)
 </script>
 
 <template>
@@ -87,7 +101,7 @@ watch(
         </div>
         <TranslationList :pos-space="false" :word="item" :showFull="showWord" v-if="showTranslate && !hydrateFailed" />
         <button v-else-if="showTranslate && hydrateFailed" class="missing-dict-hint" @click="goDictList">
-          下载 {{ missingDictName }} 查看释义
+          {{ $t('missing_dict_hint', { dictName: missingDictName }) }}
         </button>
       </div>
     </div>

--- a/packages/core/src/hooks/dict.ts
+++ b/packages/core/src/hooks/dict.ts
@@ -14,6 +14,10 @@ import { computed } from 'vue'
 export function useWordOptions() {
   const store = useBaseStore()
 
+  function ensureCurrentWordSource(val: Word) {
+    ensureWordSourceDictId(val, store.sdict.id)
+  }
+
   function isWordCollect(val: Word) {
     return !!store.collectWord.words.find(v => v.word.toLowerCase() === val.word.toLowerCase())
   }
@@ -23,9 +27,7 @@ export function useWordOptions() {
     if (rIndex > -1) {
       store.collectWord.words.splice(rIndex, 1)
     } else {
-      if (!val.sourceDictId && store.sdict.id) {
-        val.sourceDictId = store.sdict.id
-      }
+      ensureCurrentWordSource(val)
       store.collectWord.words.push(val)
     }
     store.collectWord.length = store.collectWord.words.length
@@ -40,9 +42,7 @@ export function useWordOptions() {
     if (rIndex > -1) {
       store.known.words.splice(rIndex, 1)
     } else {
-      if (!val.sourceDictId && store.sdict.id) {
-        val.sourceDictId = store.sdict.id
-      }
+      ensureCurrentWordSource(val)
       store.known.words.push(val)
     }
     store.known.length = store.known.words.length
@@ -72,6 +72,13 @@ export function useWordOptions() {
     delWrongWord,
     delSimpleWord,
   }
+}
+
+export function ensureWordSourceDictId(val: Word, sourceDictId?: string): Word {
+  if (!val.sourceDictId && sourceDictId) {
+    val.sourceDictId = sourceDictId
+  }
+  return val
 }
 
 export function useArticleOptions() {

--- a/packages/core/src/hooks/dict.ts
+++ b/packages/core/src/hooks/dict.ts
@@ -23,6 +23,9 @@ export function useWordOptions() {
     if (rIndex > -1) {
       store.collectWord.words.splice(rIndex, 1)
     } else {
+      if (!val.sourceDictId && store.sdict.id) {
+        val.sourceDictId = store.sdict.id
+      }
       store.collectWord.words.push(val)
     }
     store.collectWord.length = store.collectWord.words.length
@@ -37,6 +40,9 @@ export function useWordOptions() {
     if (rIndex > -1) {
       store.known.words.splice(rIndex, 1)
     } else {
+      if (!val.sourceDictId && store.sdict.id) {
+        val.sourceDictId = store.sdict.id
+      }
       store.known.words.push(val)
     }
     store.known.length = store.known.words.length

--- a/packages/core/src/hooks/useWordHydrator.ts
+++ b/packages/core/src/hooks/useWordHydrator.ts
@@ -1,0 +1,56 @@
+import { Word } from '../types'
+import { useBaseStore } from '../stores/base'
+
+const dictCache: Record<string, Word[]> = {}
+const pendingRequests: Record<string, Promise<Word[]>> = {}
+
+export function useWordHydrator() {
+  /**
+   * 为单词回填详细信息。词典数据可用时直接从缓存或本地词典回填；
+   * 不可用时返回失败状态，不自动触发下载。
+   * @returns hydrated=false 表示需要下载对应词典
+   */
+  async function hydrate(
+    word: Word,
+    force = false
+  ): Promise<{ hydrated: boolean; dictName?: string }> {
+    if (!word.sourceDictId || (!force && word.trans && word.trans.length > 0)) {
+      return { hydrated: true }
+    }
+
+    const dictId = word.sourceDictId
+    let wordsData: Word[] = []
+
+    if (dictCache[dictId]) {
+      wordsData = dictCache[dictId]
+    } else if (pendingRequests[dictId]) {
+      wordsData = await pendingRequests[dictId]
+    } else {
+      // 检查用户已添加的词典中是否有已加载的单词数据
+      const store = useBaseStore()
+      const userDict = store.word.bookList.find(v => v.id === dictId)
+
+      if (userDict?.words?.length) {
+        dictCache[dictId] = userDict.words
+        wordsData = userDict.words
+      } else {
+        // 词典数据不可用：不自动下载，返回失败状态
+        const dictName = userDict?.name || dictId
+        return { hydrated: false, dictName }
+      }
+    }
+
+    if (wordsData.length > 0) {
+      const sourceWord = wordsData.find(
+        w => w.word.toLowerCase() === word.word.toLowerCase()
+      )
+      if (sourceWord) {
+        const { id, sourceDictId, custom, ...details } = sourceWord
+        Object.assign(word, details)
+      }
+    }
+    return { hydrated: true }
+  }
+
+  return { hydrate }
+}

--- a/packages/core/src/hooks/useWordHydrator.ts
+++ b/packages/core/src/hooks/useWordHydrator.ts
@@ -1,15 +1,9 @@
 import { Word } from '../types'
 import { useBaseStore } from '../stores/base'
 
-const dictCache: Record<string, Word[]> = {}
-const pendingRequests: Record<string, Promise<Word[]>> = {}
+const dictIndex: Record<string, Map<string, Word>> = {}
 
 export function useWordHydrator() {
-  /**
-   * 为单词回填详细信息。词典数据可用时直接从缓存或本地词典回填；
-   * 不可用时返回失败状态，不自动触发下载。
-   * @returns hydrated=false 表示需要下载对应词典
-   */
   async function hydrate(
     word: Word,
     force = false
@@ -19,36 +13,32 @@ export function useWordHydrator() {
     }
 
     const dictId = word.sourceDictId
-    let wordsData: Word[] = []
 
-    if (dictCache[dictId]) {
-      wordsData = dictCache[dictId]
-    } else if (pendingRequests[dictId]) {
-      wordsData = await pendingRequests[dictId]
-    } else {
-      // 检查用户已添加的词典中是否有已加载的单词数据
-      const store = useBaseStore()
-      const userDict = store.word.bookList.find(v => v.id === dictId)
+    // 每次 hydrate 时检查缓存索引是否仍有效（词典是否仍在 bookList 中且有单词）
+    const store = useBaseStore()
+    const userDict = store.word.bookList.find(v => v.id === dictId)
 
-      if (userDict?.words?.length) {
-        dictCache[dictId] = userDict.words
-        wordsData = userDict.words
-      } else {
-        // 词典数据不可用：不自动下载，返回失败状态
-        const dictName = userDict?.name || dictId
-        return { hydrated: false, dictName }
-      }
+    if (!userDict?.words?.length) {
+      delete dictIndex[dictId]
+      return { hydrated: false, dictName: userDict?.name || dictId }
     }
 
-    if (wordsData.length > 0) {
-      const sourceWord = wordsData.find(
-        w => w.word.toLowerCase() === word.word.toLowerCase()
-      )
-      if (sourceWord) {
-        const { id, sourceDictId, custom, ...details } = sourceWord
-        Object.assign(word, details)
+    // 按需构建 O(1) 查找索引
+    if (!dictIndex[dictId]) {
+      const index = new Map<string, Word>()
+      for (const w of userDict.words) {
+        index.set(w.word.toLowerCase(), w)
       }
+      dictIndex[dictId] = index
     }
+
+    const sourceWord = dictIndex[dictId].get(word.word.toLowerCase())
+    if (!sourceWord) {
+      return { hydrated: false, dictName: userDict.name || dictId }
+    }
+
+    const { id, sourceDictId, custom, ...details } = sourceWord
+    Object.assign(word, details)
     return { hydrated: true }
   }
 

--- a/packages/core/src/hooks/useWordHydrator.ts
+++ b/packages/core/src/hooks/useWordHydrator.ts
@@ -1,7 +1,19 @@
 import { Word } from '../types'
 import { useBaseStore } from '../stores/base'
 
-const dictIndex: Record<string, Map<string, Word>> = {}
+type DictIndexCache = {
+  signature: string
+  index: Map<string, Word>
+}
+
+const dictIndex: Record<string, DictIndexCache> = {}
+
+function getDictSignature(words: Word[]): string {
+  const length = words.length
+  const firstWord = words[0]?.word ?? ''
+  const lastWord = words[length - 1]?.word ?? ''
+  return `${length}:${firstWord}:${lastWord}`
+}
 
 export function useWordHydrator() {
   async function hydrate(
@@ -23,16 +35,21 @@ export function useWordHydrator() {
       return { hydrated: false, dictName: userDict?.name || dictId }
     }
 
+    const signature = getDictSignature(userDict.words)
+
     // 按需构建 O(1) 查找索引
-    if (!dictIndex[dictId]) {
+    if (!dictIndex[dictId] || dictIndex[dictId].signature !== signature) {
       const index = new Map<string, Word>()
       for (const w of userDict.words) {
         index.set(w.word.toLowerCase(), w)
       }
-      dictIndex[dictId] = index
+      dictIndex[dictId] = {
+        signature,
+        index,
+      }
     }
 
-    const sourceWord = dictIndex[dictId].get(word.word.toLowerCase())
+    const sourceWord = dictIndex[dictId].index.get(word.word.toLowerCase())
     if (!sourceWord) {
       return { hydrated: false, dictName: userDict.name || dictId }
     }

--- a/packages/core/src/types/types.ts
+++ b/packages/core/src/types/types.ts
@@ -6,6 +6,7 @@ import { APP_VERSION } from '../config/env'
 export type Word = {
   id?: string
   custom?: boolean
+  sourceDictId?: string
   word: string
   phonetic0: string
   phonetic1: string

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -224,7 +224,39 @@ export async function checkAndUpgradeSaveSetting(val: any) {
 export function shakeCommonDict(n: BaseState): BaseState {
   let data: BaseState = cloneDeep(n)
   data.word.bookList.map((v: Dict) => {
-    if (!v.custom && ![DictId.wordKnown, DictId.wordWrong, DictId.wordCollect].includes(v.id)) v.words = []
+    if (!v.custom && ![DictId.wordKnown, DictId.wordWrong, DictId.wordCollect].includes(v.id)) {
+      v.words = []
+    } else if ([DictId.wordKnown, DictId.wordWrong, DictId.wordCollect].includes(v.id)) {
+      v.words.forEach(word => {
+        // 极致瘦身：如果有来源 ID，且不是自定义词典中的词，则在同步时删除几乎所有详情
+        // 详情将由前端通过 sourceDictId 动态加载
+        if (word.sourceDictId && !word.custom) {
+          word.trans = []
+          word.phonetic0 = ''
+          word.phonetic1 = ''
+          word.sentences = []
+          word.phrases = []
+          word.synos = []
+          word.relWords = { root: '', rels: [] }
+          word.etymology = []
+        } else {
+          // 平衡瘦身：针对自定义单词或旧有无来源数据
+          // 保留核心显示字段，剔除超重详情
+          word.phrases = []
+          word.synos = []
+          word.relWords = { root: '', rels: [] }
+          word.etymology = []
+
+          // 对于“已掌握”单词，即使无来源也进一步剔除释义，仅保留标识用于过滤
+          if (v.id === DictId.wordKnown) {
+            word.trans = []
+            word.sentences = []
+            word.phonetic0 = ''
+            word.phonetic1 = ''
+          }
+        }
+      })
+    }
   })
   data.article.bookList.map((v: Dict) => {
     if (!v.custom && ![DictId.articleCollect].includes(v.id)) v.articles = []


### PR DESCRIPTION
## 概述

将特殊词库（收藏、错词、已掌握）的存储模型从"全量副本"改为"引用 + 按需回填"。
实测单行 JSON 体积可从 2.36MB 降至 ~0.5MB，降幅约 80%。

### 方案

1. **来源追溯** — Word 类型新增 sourceDictId，收藏/错词/已掌握时自动注入当前词典 ID
2. **智能瘦身** — shakeCommonDict() 对同步数据分级处理：
   - 有 sourceDictId：极致瘦身（仅保留 word/id/sourceDictId，删全部详情）
   - 无来源（旧数据/自定义词）：平衡瘦身（保留 trans/phonetic/sentences）
3. **动态回填** — 新增 useWordHydrator，展示时从本地词典回填详情；词典不可用时展示提示引导用户下载

### 涉及文件

| 文件 | 变更 |
|------|------|
| packages/core/src/types/types.ts | Word 类型新增 sourceDictId |
| packages/core/src/hooks/dict.ts | 收藏/标记掌握时注入 sourceDictId |
| apps/nuxt/app/pages/(words)/practice-words/[id].vue | 错词收集时注入 sourceDictId |
| packages/core/src/utils/index.ts | shakeCommonDict 分级瘦身 |
| packages/core/src/hooks/useWordHydrator.ts | 新增：动态回填引擎 |
| packages/core/src/components/word/WordItem.vue | 触发回填 + 缺失时展示提示 |

### 兼容性

- **旧同步数据**：无 sourceDictId 的单词走平衡瘦身，旧版 app 仍可显示释义
- **新同步数据**：有 sourceDictId 的单词极致瘦身，旧版 app 仅显示单词名（不报错）
- **下次同步自动优化**：shakeCommonDict 在每次同步时执行，已有数据自动瘦身

### 测试

- [x] 收藏/错词/已掌握正常注入 sourceDictId
- [x] 同步前后 IndexedDB 与 Supabase 数据一致
- [x] 删除词典后列表仅显示单词名，展示下载 XX 查看释义提示
- [x] 点击提示跳转词典列表页
- [x] 旧数据（无 sourceDictId）正常显示
- [x] 离线模式正常

Closes #260