### PR TITLE
fix: prevent hidden-word flicker when switching practice words

### DIFF
--- a/apps/vscode-web/src/z-polyfill/TypeWord.vue
+++ b/apps/vscode-web/src/z-polyfill/TypeWord.vue
@@ -92,6 +92,15 @@ let isWordTest = $computed(() => {
   )
 })
 
+let shouldHideWordByDefault = $computed(() => {
+  return [
+    WordPracticeType.Spell,
+    WordPracticeType.Listen,
+    WordPracticeType.Dictation,
+    WordPracticeType.Identify,
+  ].includes(settingStore.wordPracticeType)
+})
+
 // 在全局对象中存储当前单词信息，以便其他模块可以访问
 function updateCurrentWordInfo() {
   window.__CURRENT_WORD_INFO__ = {
@@ -102,7 +111,11 @@ function updateCurrentWordInfo() {
   }
 }
 
-watch(() => props.word, reset, { deep: true })
+watch(
+  () => props.word,
+  reset,
+  { flush: 'sync' }
+)
 
 function reset() {
   clearJumpTimer()
@@ -624,7 +637,7 @@ const isCollect = $computed(() => isWordCollect(props.word))
       <div class="flex gap-space items-end mb-2">
         <Tooltip
           :title="
-            settingStore.dictation ? `可以按快捷键 ${settingStore.shortcutKeyMap[ShortcutKey.ShowWord]} 显示单词` : ''
+            shouldHideWordByDefault ? `可以按快捷键 ${settingStore.shortcutKeyMap[ShortcutKey.ShowWord]} 显示单词` : ''
           "
         >
           <div id="word" class="word" :class="wrong && 'is-wrong'" @mouseenter="showWord" @mouseleave="mouseleave">
@@ -648,7 +661,7 @@ const isCollect = $computed(() => isWordCollect(props.word))
             <template v-else>
               <span class="input" v-if="input">{{ input }}</span>
               <span class="wrong" v-if="wrong">{{ wrong }}</span>
-              <span class="letter" v-if="settingStore.dictation && !showFullWord">
+              <span class="letter" v-if="shouldHideWordByDefault && !showFullWord">
                 {{
                   displayWord
                     .split('')
@@ -728,7 +741,7 @@ const isCollect = $computed(() => isWordCollect(props.word))
           <span class="shrink-0 mr-1" :class="v.pos ? 'en-article-family' : ''">
             {{ v.pos }}
           </span>
-          <span v-if="!settingStore.dictation || showWordResult || showFullWord">{{ v.cn }}</span>
+          <span v-if="!shouldHideWordByDefault || showWordResult || showFullWord">{{ v.cn }}</span>
           <SentenceHightLightWord v-else :text="v.cn" :word="word.word" :dictation="true" :high-light="false" />
         </div>
       </div>

--- a/packages/core/src/components/word/TypeWord.vue
+++ b/packages/core/src/components/word/TypeWord.vue
@@ -121,6 +121,15 @@ let isWordTest = $computed(() => {
   )
 })
 
+let shouldHideWordByDefault = $computed(() => {
+  return [
+    WordPracticeType.Spell,
+    WordPracticeType.Listen,
+    WordPracticeType.Dictation,
+    WordPracticeType.Identify,
+  ].includes(settingStore.wordPracticeType)
+})
+
 // 在全局对象中存储当前单词信息，以便其他模块可以访问
 function updateCurrentWordInfo() {
   window.__CURRENT_WORD_INFO__ = {
@@ -131,7 +140,11 @@ function updateCurrentWordInfo() {
   }
 }
 
-watch(() => props.word, reset, { deep: true })
+watch(
+  () => props.word,
+  reset,
+  { flush: 'sync' }
+)
 
 function reset() {
   clearJumpTimer()
@@ -696,7 +709,9 @@ const isCollect = $computed(() => isWordCollect(props.word))
       </div>
 
       <Tooltip
-        :title="settingStore.dictation ? `快捷键 ${settingStore.shortcutKeyMap[ShortcutKey.ShowWord]} 显示单词` : ''"
+        :title="
+          shouldHideWordByDefault ? `快捷键 ${settingStore.shortcutKeyMap[ShortcutKey.ShowWord]} 显示单词` : ''
+        "
       >
         <div
           id="word"
@@ -728,7 +743,7 @@ const isCollect = $computed(() => isWordCollect(props.word))
             <div v-if="currentPracticeSentenceIndex === -1">
               <span class="input" v-if="input">{{ input }}</span>
               <span class="wrong" v-if="wrong">{{ wrong }}</span>
-              <span class="letter" v-if="settingStore.dictation && !showFullWord">
+              <span class="letter" v-if="shouldHideWordByDefault && !showFullWord">
                 {{
                   displayWord
                     .split('')
@@ -835,7 +850,7 @@ const isCollect = $computed(() => isWordCollect(props.word))
           fontSize: settingStore.fontSize.wordTranslateFontSize + 'px',
         }"
       >
-        <TranslationList :word="word" :showFull="!settingStore.dictation || showWordResult || showFullWord" />
+        <TranslationList :word="word" :showFull="!shouldHideWordByDefault || showWordResult || showFullWord" />
       </div>
     </div>
 


### PR DESCRIPTION
## Summary

- 修复了在低性能场景（如节能模式）下，切换到下一个单词时“本应隐藏的单词短暂闪现”的问题。

## Root Cause

- 在 props.word 切换时，上一词的瞬时 UI 状态（如 showWordResult、showFullWord）有机会先被渲染一帧，再被 reset 覆盖。
- 在设备性能不足或调度延迟时，这个时序窗口更容易出现，从而造成可见抖动。

## Changes

- 将单词切换时的 reset 监听改为同步刷新（flush: 'sync'），确保在同一更新周期内完成重置。
- 引入稳定的显隐判定 shouldHideWordByDefault，统一“默认隐藏单词”的模式判断。
- 将单词和释义相关渲染路径统一接入该判定，避免首帧状态泄漏导致的闪现。

## Affected Modes

- 默认隐藏：Spell、Listen、Dictation、Identify
- 默认显示：FollowWrite

## Validation

- 本地手动验证：在非照着打模式下连续切词，未再出现“先显示几帧再隐藏”的现象。
- 编辑器静态检查：改动文件无新增报错。

## Scope

- Core TypeWord 组件
- vscode-web TypeWord 对应实现