### PR TITLE
fix: not properly marked wrong

### DIFF
--- a/packages/core/src/components/word/TypeWord.vue
+++ b/packages/core/src/components/word/TypeWord.vue
@@ -743,7 +743,7 @@ const isCollect = $computed(() => isWordCollect(props.word))
           :title="`发音(${settingStore.shortcutKeyMap[ShortcutKey.PlayWordPronunciation]})`"
           ref="volumeIconRef"
           :simple="true"
-          :cb="() => playWordAudio(word.word)"
+          :cb="() => play()"
         />
       </div>
 


### PR DESCRIPTION
通过点击按钮播放音频也应当标记成错误