### PR TITLE
fix: skipStep

### DIFF
--- a/apps/nuxt/app/pages/(words)/practice-words/[id].vue
+++ b/apps/nuxt/app/pages/(words)/practice-words/[id].vue
@@ -689,7 +689,9 @@ function checkWordIsNeedNext(word: Word) {
 
 function skipStep() {
   data.index = data.words.length - 1
-  data.wrongWords = []
+  if (statStore.stage !== WordPracticeStage.IdentifyReview) {
+    data.wrongWords = []
+  }
   next(false, true)
 }
 


### PR DESCRIPTION
close #298
- 确保在自测旧词时点跳过阶段, 如果有错词能进入跟写阶段