### PR TITLE
feat: enhance footer

### DIFF
--- a/packages/core/src/components/word/Footer.vue
+++ b/packages/core/src/components/word/Footer.vue
@@ -324,10 +324,23 @@ const stages = $computed(() => {
       .row {
         @apply flex flex-col items-center gap-1 text-gray;
 
+        width: 4rem;
+        padding: 0 0 0.5rem 0;
+
         .line {
           height: 1px;
           width: 100%;
           background: var(--color-sub-gray);
+        }
+
+        .num {
+          line-height: 1;
+          height: 1rem;
+        }
+
+        .name {
+          line-height: 1;
+          height: 1rem;
         }
       }
     }


### PR DESCRIPTION
- 确保大多数情况下, footer左侧里的几个box中的文字都能对齐, 并固定box宽度

前:
<img width="840" height="130" alt="截图 2026-08-05 22-39-07" src="https://github.com/user-attachments/assets/9127b42a-ca42-4e07-a216-790c14466978" />

后:
<img width="840" height="130" alt="截图 2026-08-05 22-39-22" src="https://github.com/user-attachments/assets/511270e9-0eb4-4d9e-8fdf-6d7e7658093f" />
