### PR TITLE
 fix: dead-key layouts cannot type the apostrophe and the composition space skips the word

### DIFF
--- a/app/core/hooks/event.ts
+++ b/app/core/hooks/event.ts
@@ -2,11 +2,7 @@ import {onDeactivated, onMounted, onUnmounted, watch, type WatchSource} from 'vu
 import {emitter, EventKey} from '../utils/eventBus'
 import {useSettingStore} from '../stores'
 import {isMobile} from '../utils'
-import {
-  confirmCharacterInserted,
-  isDeadKeyEvent,
-  shouldIgnoreDeadKeyCompositionSpace,
-} from '../utils/dead-key-composition'
+import {shouldIgnoreDeadKeyCompositionSpace} from '../utils/dead-key-composition'
 import {Toast} from '@/base'
 
 const CODE_TO_CHAR: Record<string, string> = {
@@ -84,6 +80,9 @@ export function useWindowClick(cb: (e: PointerEvent) => void) {
   onDeactivated(remove)
 }
 
+// 组合状态（IME/死键）共享给全局 keydown 处理：组合进行中时空格是终结符而非分词符
+let isComposing = false
+
 export function useEventListener(type: string, listener: EventListenerOrEventListenerObject) {
   const invokeListener = (event: KeyboardEvent) => {
     if (typeof listener === 'function') {
@@ -150,7 +149,6 @@ export function useEventListener(type: string, listener: EventListenerOrEventLis
       }
 
       const hiddenInput = ensureMobileInput()
-      let isComposing = false
 
       const createSyntheticEvent = (payload: { key: string; code?: string; keyCode: number }) => {
         const base = {
@@ -179,12 +177,15 @@ export function useEventListener(type: string, listener: EventListenerOrEventLis
       const handleCompositionStart = () => {
         // console.log('handleCompositionStart',Date.now())
         isComposing = true
-        Toast.warning('请切换到英文输入')
       }
 
       const handleCompositionEnd = (event: CompositionEvent) => {
         isComposing = false
-        confirmCharacterInserted()
+        // 死键（´、`、^…）组合也走 composition 事件，但它们不是 IME；只有产出 CJK/全角
+        // 文本才是真正的输入法，此时才提示切换到英文，避免死键每次都弹警告
+        if (event.data && /[\u4e00-\u9fff\u3040-\u30ff\uac00-\ud7af\uff00-\uffef]/.test(event.data)) {
+          Toast.warning('请切换到英文输入')
+        }
         if (!event.data) {
           hiddenInput.value = ' '
           return
@@ -203,9 +204,11 @@ export function useEventListener(type: string, listener: EventListenerOrEventLis
       const handleInput = (event: InputEvent) => {
         // console.log('handleInput',event,Date.now())
         if (isComposing) return
+        // Firefox 的 input 事件晚于 compositionend 到达，此时输入框已被重置为哨兵 ' '，
+        // slice(-1) 会把哨兵空格派发成幽灵空格；组合字符已由 handleCompositionEnd 派发过
+        if (event.inputType === 'insertCompositionText' || event.inputType === 'insertFromComposition') return
         const target = event.target as HTMLInputElement | null
         if (!target) return
-        confirmCharacterInserted()
         let char = ''
         let keyCode = -1
         if (event.inputType === 'deleteContentBackward') {
@@ -324,13 +327,18 @@ export function useStartKeyboardEventListener() {
   const settingStore = useSettingStore()
 
   useEventListener('keydown', (e: KeyboardEvent) => {
+    // 组合进行中（死键/IME）的空格是"终结/取消"组合的键，不是分词空格，必须吞掉
+    if (isComposing && e.code === 'Space' && e.key === ' ') {
+      e.preventDefault()
+      return
+    }
     // 死键布局（西班牙语/US-Intl）中 ' 的 keydown 是组合起点，组合空格的终结在此吞掉
     if (shouldIgnoreDeadKeyCompositionSpace(e)) {
       e.preventDefault()
       return
     }
-    // 死键本身不产生字符，字符由系统组合后经隐藏输入框 input 事件送入（自适应客户端布局）
-    if (isDeadKeyEvent(e)) {
+    // 死键本身不产生字符，字符由系统组合后经隐藏输入框 input 事件送入
+    if (e.key === 'Dead') {
       e.preventDefault()
       return
     }

--- a/app/core/hooks/event.ts
+++ b/app/core/hooks/event.ts
@@ -2,6 +2,11 @@ import {onDeactivated, onMounted, onUnmounted, watch, type WatchSource} from 'vu
 import {emitter, EventKey} from '../utils/eventBus'
 import {useSettingStore} from '../stores'
 import {isMobile} from '../utils'
+import {
+  confirmCharacterInserted,
+  isDeadKeyEvent,
+  shouldIgnoreDeadKeyCompositionSpace,
+} from '../utils/dead-key-composition'
 import {Toast} from '@/base'
 
 const CODE_TO_CHAR: Record<string, string> = {
@@ -179,6 +184,7 @@ export function useEventListener(type: string, listener: EventListenerOrEventLis
 
       const handleCompositionEnd = (event: CompositionEvent) => {
         isComposing = false
+        confirmCharacterInserted()
         if (!event.data) {
           hiddenInput.value = ' '
           return
@@ -199,6 +205,7 @@ export function useEventListener(type: string, listener: EventListenerOrEventLis
         if (isComposing) return
         const target = event.target as HTMLInputElement | null
         if (!target) return
+        confirmCharacterInserted()
         let char = ''
         let keyCode = -1
         if (event.inputType === 'deleteContentBackward') {
@@ -317,6 +324,16 @@ export function useStartKeyboardEventListener() {
   const settingStore = useSettingStore()
 
   useEventListener('keydown', (e: KeyboardEvent) => {
+    // 死键布局（西班牙语/US-Intl）中 ' 的 keydown 是组合起点，组合空格的终结在此吞掉
+    if (shouldIgnoreDeadKeyCompositionSpace(e)) {
+      e.preventDefault()
+      return
+    }
+    // 死键本身不产生字符，字符由系统组合后经隐藏输入框 input 事件送入（自适应客户端布局）
+    if (isDeadKeyEvent(e)) {
+      e.preventDefault()
+      return
+    }
     // console.log('keydown', e)
     // debugger
     //解决无法复制、全选的问题

--- a/app/core/utils/dead-key-composition.ts
+++ b/app/core/utils/dead-key-composition.ts
@@ -1,51 +1,11 @@
 /**
- * 死键（dead key）组合处理 —— 兼容两种浏览器事件模型，自适应客户端键盘布局
- *
- * 西班牙语、国际美式等布局把 ' 等键作为重音死键：单独按下不产生字符，必须再按
- * 一个"组合终结符"（通常是空格）才会把死键落成实际字符（如 '），这枚组合空格
- * 会被系统消费，不是真正的分词空格。
- *
- * 浏览器对死键的 keydown 报告有两种模型，这里同时兼容：
- * 1. key='Dead'（Chromium/Gecko 常见）：死键本身不产生字符，字符由系统组合后
- *    经隐藏输入框的 input 事件送入，直接丢弃该 keydown 即可。
- * 2. 把死键报成基础字符（如 '，部分环境）：keydown 看似普通按键，但实际没有
- *    插入任何字符。用隐藏输入框是否产生 input 事件作为"字符是否真的落盘"的
- *    依据：撇号类键按下后如果没有字符落盘，下一个空格就是组合终结符。
- *
- * 普通英文布局不受影响：' 是真实按键，按下后立即产生 input 事件，状态随即复位，
- * 后面的空格照常作为分词空格处理。
+ * 死键（dead key）处理：Chromium/Gecko 在死键布局（西班牙语、国际美式等）下把
+ * 死键报告为 key='Dead'。死键本身不产生字符，字符由系统组合后经隐藏输入框的
+ * input 事件送进输入逻辑；紧跟死键的空格是组合终结符，会被系统消费，不是分词空格。
  */
-
-/** 浏览器明确报告的死键（模型 1）。 */
-export function isDeadKeyEvent(event: { key: string }): boolean {
-  return event.key === 'Dead'
-}
-
-/** 可能以基础字符形式报告的死键：撇号/双引号死键（模型 2 需要监听）。 */
-function isApostropheDeadKeyCandidate(event: { key: string; code: string }): boolean {
-  return event.code === 'Quote' && (event.key === "'" || event.key === '"')
-}
-
-export function isSpaceKeydownEvent(event: {
-  key: string
-  code: string
-  ctrlKey?: boolean
-  metaKey?: boolean
-  altKey?: boolean
-}): boolean {
-  if (event.ctrlKey || event.metaKey || event.altKey) return false
-  return event.code === 'Space' && event.key === ' '
-}
-
 let lastKeyDownWasDeadKey = false
-let pendingQuoteComposition = false
 
-/**
- * 跟踪 keydown 序列（对每个 keydown 调用一次）。
- *
- * 返回 true 表示这次空格是死键组合终结符，应当被吞掉，不交给输入逻辑处理；
- * 返回 false 则正常分发。吞掉后内部状态随之复位，不影响后续输入。
- */
+/** 返回 true 表示这次空格是死键组合终结符，应吞掉；对其他键跟踪死键状态。 */
 export function shouldIgnoreDeadKeyCompositionSpace(event: {
   key: string
   code: string
@@ -53,35 +13,17 @@ export function shouldIgnoreDeadKeyCompositionSpace(event: {
   metaKey?: boolean
   altKey?: boolean
 }): boolean {
-  if (isSpaceKeydownEvent(event)) {
-    if (lastKeyDownWasDeadKey || pendingQuoteComposition) {
-      lastKeyDownWasDeadKey = false
-      pendingQuoteComposition = false
-      return true
-    }
-    return false
+  if (event.ctrlKey || event.metaKey || event.altKey) return false
+  if (event.code === 'Space' && event.key === ' ') {
+    const isTerminator = lastKeyDownWasDeadKey
+    lastKeyDownWasDeadKey = false
+    return isTerminator
   }
-  if (isDeadKeyEvent(event)) {
-    lastKeyDownWasDeadKey = true
-    pendingQuoteComposition = false
-    return false
-  }
-  lastKeyDownWasDeadKey = false
-  // 模型 2：撇号类按键进入"待组合"状态，直到真实字符落盘或下一个按键到来
-  pendingQuoteComposition = isApostropheDeadKeyCandidate(event)
+  lastKeyDownWasDeadKey = event.key === 'Dead'
   return false
-}
-
-/**
- * 系统向隐藏输入框真实写入了一个字符时调用（input / compositionend 事件）。
- * 复位待组合状态：字符已经落盘，说明前面的按键是真实按键而非死键。
- */
-export function confirmCharacterInserted(): void {
-  pendingQuoteComposition = false
 }
 
 /** 复位内部状态，便于测试隔离。 */
 export function resetDeadKeyCompositionState(): void {
   lastKeyDownWasDeadKey = false
-  pendingQuoteComposition = false
 }

--- a/app/core/utils/dead-key-composition.ts
+++ b/app/core/utils/dead-key-composition.ts
@@ -1,0 +1,87 @@
+/**
+ * 死键（dead key）组合处理 —— 兼容两种浏览器事件模型，自适应客户端键盘布局
+ *
+ * 西班牙语、国际美式等布局把 ' 等键作为重音死键：单独按下不产生字符，必须再按
+ * 一个"组合终结符"（通常是空格）才会把死键落成实际字符（如 '），这枚组合空格
+ * 会被系统消费，不是真正的分词空格。
+ *
+ * 浏览器对死键的 keydown 报告有两种模型，这里同时兼容：
+ * 1. key='Dead'（Chromium/Gecko 常见）：死键本身不产生字符，字符由系统组合后
+ *    经隐藏输入框的 input 事件送入，直接丢弃该 keydown 即可。
+ * 2. 把死键报成基础字符（如 '，部分环境）：keydown 看似普通按键，但实际没有
+ *    插入任何字符。用隐藏输入框是否产生 input 事件作为"字符是否真的落盘"的
+ *    依据：撇号类键按下后如果没有字符落盘，下一个空格就是组合终结符。
+ *
+ * 普通英文布局不受影响：' 是真实按键，按下后立即产生 input 事件，状态随即复位，
+ * 后面的空格照常作为分词空格处理。
+ */
+
+/** 浏览器明确报告的死键（模型 1）。 */
+export function isDeadKeyEvent(event: { key: string }): boolean {
+  return event.key === 'Dead'
+}
+
+/** 可能以基础字符形式报告的死键：撇号/双引号死键（模型 2 需要监听）。 */
+function isApostropheDeadKeyCandidate(event: { key: string; code: string }): boolean {
+  return event.code === 'Quote' && (event.key === "'" || event.key === '"')
+}
+
+export function isSpaceKeydownEvent(event: {
+  key: string
+  code: string
+  ctrlKey?: boolean
+  metaKey?: boolean
+  altKey?: boolean
+}): boolean {
+  if (event.ctrlKey || event.metaKey || event.altKey) return false
+  return event.code === 'Space' && event.key === ' '
+}
+
+let lastKeyDownWasDeadKey = false
+let pendingQuoteComposition = false
+
+/**
+ * 跟踪 keydown 序列（对每个 keydown 调用一次）。
+ *
+ * 返回 true 表示这次空格是死键组合终结符，应当被吞掉，不交给输入逻辑处理；
+ * 返回 false 则正常分发。吞掉后内部状态随之复位，不影响后续输入。
+ */
+export function shouldIgnoreDeadKeyCompositionSpace(event: {
+  key: string
+  code: string
+  ctrlKey?: boolean
+  metaKey?: boolean
+  altKey?: boolean
+}): boolean {
+  if (isSpaceKeydownEvent(event)) {
+    if (lastKeyDownWasDeadKey || pendingQuoteComposition) {
+      lastKeyDownWasDeadKey = false
+      pendingQuoteComposition = false
+      return true
+    }
+    return false
+  }
+  if (isDeadKeyEvent(event)) {
+    lastKeyDownWasDeadKey = true
+    pendingQuoteComposition = false
+    return false
+  }
+  lastKeyDownWasDeadKey = false
+  // 模型 2：撇号类按键进入"待组合"状态，直到真实字符落盘或下一个按键到来
+  pendingQuoteComposition = isApostropheDeadKeyCandidate(event)
+  return false
+}
+
+/**
+ * 系统向隐藏输入框真实写入了一个字符时调用（input / compositionend 事件）。
+ * 复位待组合状态：字符已经落盘，说明前面的按键是真实按键而非死键。
+ */
+export function confirmCharacterInserted(): void {
+  pendingQuoteComposition = false
+}
+
+/** 复位内部状态，便于测试隔离。 */
+export function resetDeadKeyCompositionState(): void {
+  lastKeyDownWasDeadKey = false
+  pendingQuoteComposition = false
+}

--- a/tests/unit/dead-key-composition.test.ts
+++ b/tests/unit/dead-key-composition.test.ts
@@ -1,8 +1,5 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 import {
-  confirmCharacterInserted,
-  isDeadKeyEvent,
-  isSpaceKeydownEvent,
   resetDeadKeyCompositionState,
   shouldIgnoreDeadKeyCompositionSpace,
 } from '../../app/core/utils/dead-key-composition.ts'
@@ -12,44 +9,25 @@ describe('dead key composition space swallowing', () => {
     resetDeadKeyCompositionState()
   })
 
-  it('only treats keys the browser explicitly reports as Dead as dead keys — no layout guessing', () => {
-    expect(isDeadKeyEvent({ key: 'Dead' })).toBe(true)
-    expect(isDeadKeyEvent({ key: "'", code: 'Quote' })).toBe(false)
-  })
-
-  it('model 1 (key="Dead", Chromium/Gecko): swallows the composition space (es / US-Intl)', () => {
+  it('swallows the space that terminates a dead-key composition (es / US-Intl, key=Dead)', () => {
     expect(shouldIgnoreDeadKeyCompositionSpace({ key: 'Dead', code: 'Quote' })).toBe(false)
     expect(shouldIgnoreDeadKeyCompositionSpace({ key: ' ', code: 'Space' })).toBe(true)
     expect(shouldIgnoreDeadKeyCompositionSpace({ key: ' ', code: 'Space' })).toBe(false)
   })
 
-  it('model 2 (dead key reported as base char): swallows the space while no real character landed', () => {
-    // 死键以 ' 报告，且按下后没有任何字符落盘 → 紧跟的空格是组合终结符
-    expect(shouldIgnoreDeadKeyCompositionSpace({ key: "'", code: 'Quote' })).toBe(false)
-    expect(shouldIgnoreDeadKeyCompositionSpace({ key: ' ', code: 'Space' })).toBe(true)
-  })
-
-  it('model 2 with real insertion (plain English): apostrophe lands, so the space is real', () => {
-    expect(shouldIgnoreDeadKeyCompositionSpace({ key: "'", code: 'Quote' })).toBe(false)
-    // 系统真正插入了 '（隐藏输入框 input 事件）
-    confirmCharacterInserted()
-    expect(shouldIgnoreDeadKeyCompositionSpace({ key: ' ', code: 'Space' })).toBe(false)
-  })
-
-  it('resets the quoted-composition state after any intermediate non-space key', () => {
-    expect(shouldIgnoreDeadKeyCompositionSpace({ key: "'", code: 'Quote' })).toBe(false)
+  it('does not swallow a normal space after a regular letter (plain English layout)', () => {
     expect(shouldIgnoreDeadKeyCompositionSpace({ key: 's', code: 'KeyS' })).toBe(false)
     expect(shouldIgnoreDeadKeyCompositionSpace({ key: ' ', code: 'Space' })).toBe(false)
   })
 
-  it('swallows the space for double-quote dead keys too (US-Intl shift+quote)', () => {
-    expect(shouldIgnoreDeadKeyCompositionSpace({ key: '"', code: 'Quote' })).toBe(false)
-    expect(shouldIgnoreDeadKeyCompositionSpace({ key: ' ', code: 'Space' })).toBe(true)
+  it('resets the dead key flag after any intermediate non-space key', () => {
+    expect(shouldIgnoreDeadKeyCompositionSpace({ key: 'Dead', code: 'Quote' })).toBe(false)
+    expect(shouldIgnoreDeadKeyCompositionSpace({ key: 'x', code: 'KeyX' })).toBe(false)
+    expect(shouldIgnoreDeadKeyCompositionSpace({ key: ' ', code: 'Space' })).toBe(false)
   })
 
-  it('identifies plain space keydowns only', () => {
-    expect(isSpaceKeydownEvent({ key: ' ', code: 'Space' })).toBe(true)
-    expect(isSpaceKeydownEvent({ key: ' ', code: 'Space', metaKey: true })).toBe(false)
-    expect(isSpaceKeydownEvent({ key: '\t', code: 'Tab' })).toBe(false)
+  it('never swallows spaces pressed with modifiers', () => {
+    expect(shouldIgnoreDeadKeyCompositionSpace({ key: 'Dead', code: 'Quote' })).toBe(false)
+    expect(shouldIgnoreDeadKeyCompositionSpace({ key: ' ', code: 'Space', metaKey: true })).toBe(false)
   })
 })

--- a/tests/unit/dead-key-composition.test.ts
+++ b/tests/unit/dead-key-composition.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  confirmCharacterInserted,
+  isDeadKeyEvent,
+  isSpaceKeydownEvent,
+  resetDeadKeyCompositionState,
+  shouldIgnoreDeadKeyCompositionSpace,
+} from '../../app/core/utils/dead-key-composition.ts'
+
+describe('dead key composition space swallowing', () => {
+  beforeEach(() => {
+    resetDeadKeyCompositionState()
+  })
+
+  it('only treats keys the browser explicitly reports as Dead as dead keys — no layout guessing', () => {
+    expect(isDeadKeyEvent({ key: 'Dead' })).toBe(true)
+    expect(isDeadKeyEvent({ key: "'", code: 'Quote' })).toBe(false)
+  })
+
+  it('model 1 (key="Dead", Chromium/Gecko): swallows the composition space (es / US-Intl)', () => {
+    expect(shouldIgnoreDeadKeyCompositionSpace({ key: 'Dead', code: 'Quote' })).toBe(false)
+    expect(shouldIgnoreDeadKeyCompositionSpace({ key: ' ', code: 'Space' })).toBe(true)
+    expect(shouldIgnoreDeadKeyCompositionSpace({ key: ' ', code: 'Space' })).toBe(false)
+  })
+
+  it('model 2 (dead key reported as base char): swallows the space while no real character landed', () => {
+    // 死键以 ' 报告，且按下后没有任何字符落盘 → 紧跟的空格是组合终结符
+    expect(shouldIgnoreDeadKeyCompositionSpace({ key: "'", code: 'Quote' })).toBe(false)
+    expect(shouldIgnoreDeadKeyCompositionSpace({ key: ' ', code: 'Space' })).toBe(true)
+  })
+
+  it('model 2 with real insertion (plain English): apostrophe lands, so the space is real', () => {
+    expect(shouldIgnoreDeadKeyCompositionSpace({ key: "'", code: 'Quote' })).toBe(false)
+    // 系统真正插入了 '（隐藏输入框 input 事件）
+    confirmCharacterInserted()
+    expect(shouldIgnoreDeadKeyCompositionSpace({ key: ' ', code: 'Space' })).toBe(false)
+  })
+
+  it('resets the quoted-composition state after any intermediate non-space key', () => {
+    expect(shouldIgnoreDeadKeyCompositionSpace({ key: "'", code: 'Quote' })).toBe(false)
+    expect(shouldIgnoreDeadKeyCompositionSpace({ key: 's', code: 'KeyS' })).toBe(false)
+    expect(shouldIgnoreDeadKeyCompositionSpace({ key: ' ', code: 'Space' })).toBe(false)
+  })
+
+  it('swallows the space for double-quote dead keys too (US-Intl shift+quote)', () => {
+    expect(shouldIgnoreDeadKeyCompositionSpace({ key: '"', code: 'Quote' })).toBe(false)
+    expect(shouldIgnoreDeadKeyCompositionSpace({ key: ' ', code: 'Space' })).toBe(true)
+  })
+
+  it('identifies plain space keydowns only', () => {
+    expect(isSpaceKeydownEvent({ key: ' ', code: 'Space' })).toBe(true)
+    expect(isSpaceKeydownEvent({ key: ' ', code: 'Space', metaKey: true })).toBe(false)
+    expect(isSpaceKeydownEvent({ key: '\t', code: 'Tab' })).toBe(false)
+  })
+})


### PR DESCRIPTION
On layouts with dead keys (Spanish, French, US-International, Nordic...),
an apostrophe requires pressing the dead key and then Space, but that
composition Space is consumed by the OS — not a real separator — yet it
was treated as one, skipping the word being typed. Chromium/Gecko also
report the dead key as `key='Dead'`, which ended up in the input literally.

Changes:
- drop plain `key='Dead'` keydowns; the actual character is delivered by
  the OS composition through the hidden input's input event
- swallow the Space that terminates a dead-key composition (both the
  `key='Dead'` path and the composition-events path while composing)
- show the existing "switch to English input" warning only for real
  CJK/IME output, so dead-key layouts stop getting spammed by it
- add unit tests covering the dead-key swallow, plain-English
  no-regression and state reset

Fixes #304